### PR TITLE
Admin password reset capability

### DIFF
--- a/app/Http/Controllers/Auth/ChangePasswordController.php
+++ b/app/Http/Controllers/Auth/ChangePasswordController.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Auth\Events\PasswordReset;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rules;
+use Throwable;
+
+class ChangePasswordController extends Controller
+{
+    /**
+     * Adiministrative function which returns a confirmation page for the
+     * admin password reset flow.
+     *
+     * @param Request $request The incoming request
+     * @param User $user The User whose password needs resetting
+     * @return void
+     */
+    public function approveReset(Request $request, User $user)
+    {
+        if ($request->user()->cannot('update', $user)) {
+            return abort(403);
+        }
+
+        return view('users.approve-reset')->with(compact('user'));
+    }
+
+    /**
+     * Administrative function allowing direct password resets for users by
+     * administrators. The password is set to 'password' and the password_reset
+     * flag is set to 'true' which will force the user to change the password
+     * upon successful login or any page navigation.
+     *
+     * @param Request $request The incoming request
+     * @param User $user The User whose password will be reset
+     * @return void
+     */
+    public function adminReset(Request $request, User $user)
+    {
+        if ($request->user()->cannot('update', $user)) {
+            return abort(403);
+        }
+
+        $user->forceFill([
+            'password' => Hash::make('password'),
+            'password_reset' => true,
+        ])->save();
+
+        $users = User::all();
+
+        return view('users.index')->with(compact('users'));
+    }
+
+    /**
+     * Show the confirm password view.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function show()
+    {
+        return view('auth.change-password');
+    }
+
+    /**
+     * Handle an incoming new password request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\RedirectResponse
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+        ]);
+
+        $user = $request->user();
+        try {
+            $user->forceFill([
+                'password' => Hash::make($request->password),
+                'remember_token' => Str::random(60),
+                'password_reset' => false,
+            ])->save();
+            $status = true;
+            event(new PasswordReset($user));
+        } catch (Throwable $e) {
+            Log::error("Failed to change user password", [$e]);
+            $status = false;
+        }
+
+
+        // Here we will attempt to reset the user's password. If it is successful we
+        // will update the password on an actual user model and persist it to the
+        // database. Otherwise we will parse the error and return the response.
+        // $status = Password::reset(
+        //     $request->only('email', 'password', 'password_confirmation', 'token'),
+        //     function ($user) use ($request) {
+        //         $user->forceFill([
+        //             'password' => Hash::make($request->password),
+        //             'remember_token' => Str::random(60),
+        //         ])->save();
+
+        //         event(new PasswordReset($user));
+        //     }
+        // );
+
+        // If the password was successfully reset, we will redirect the user back to
+        // the application's home authenticated view. If there is an error we can
+        // redirect them back to where they came from with their error message.
+
+        return $status
+            ? view('auth.change-password')->with(['status' => true])
+            : back()->withErrors(compact('status'));
+        // return $status
+        //     ? back()->with(compact('status'))
+        //     : back()->with(compact('status'))
+        //     ->withErrors(['password' => __($status)]);
+    }
+}

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -13,11 +13,11 @@ class UsersController extends Controller
             return abort(403);
         }
 
-        $user = user::query()
+        $users = User::query()
             ->get();
 
         return view('users.index')
-            ->with(compact('user'));
+            ->with(compact('users'));
     }
 
     public function edit(Request $request)

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -64,5 +64,6 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'forceChangePassword' => \App\Http\Middleware\ForceChangePassword::class,
     ];
 }

--- a/app/Http/Middleware/ForceChangePassword.php
+++ b/app/Http/Middleware/ForceChangePassword.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Auth;
+
+class ForceChangePassword
+{
+    /**
+     * Check to see if the user's password_reset flag is true, if so redirect them to change their password.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     */
+    public function handle($request, Closure $next)
+    {
+        if (Auth::user() &&  Auth::user()->password_reset == 1) {
+                return redirect()->route('password.change-show')->with(['message' => 'Your password has been reset, please make a new one to continue.']);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -78,7 +78,7 @@ class UserPolicy
      */
     public function update(User $user, User $model)
     {
-        return false;
+        return $user->id === $model->id;
     }
 
     /**

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /**
@@ -24,9 +25,10 @@ class UserFactory extends Factory
             'email' => fake()->safeEmail(),
             'email_verified_at' => now(),
             'badge_number' => fake()->randomNumber(4),
-            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'password' => Hash::make('password'), // password
             'remember_token' => Str::random(10),
-            'team_id' => '1'
+            'team_id' => '1',
+            'password_reset' => '1',
         ];
     }
 

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -20,6 +20,7 @@ return new class extends Migration
             $table->timestamp('email_verified_at')->nullable();
             $table->integer('badge_number')->nullable();
             $table->boolean('is_admin')->default(false);
+            $table->boolean('password_reset')->default(false);
             $table->string('password');
             $table->foreignId('team_id')->nullable();
             $table->rememberToken();

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -7,6 +7,7 @@ use App\Models\Team;
 use App\Models\Activities;
 use App\Models\LoggedActivities;
 use App\Models\User;
+use Illuminate\Support\Facades\Hash;
 use Ramsey\Uuid\Guid\Guid;
 
 class DatabaseSeeder extends Seeder
@@ -18,6 +19,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
+        $defaultPassword = 'password';
 
         if (getenv("APP_ENV") === 'production') {
             // Create basic team
@@ -43,6 +45,7 @@ class DatabaseSeeder extends Seeder
             $user->email = 'root@notAGmail.com';
             $user->password = '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi';
             $user->is_admin = true;
+            $user->password_reset = true;
             $user->save();
         } else if (getenv("APP_ENV") === 'stage') {
             // Create basic team
@@ -66,8 +69,9 @@ class DatabaseSeeder extends Seeder
             $user->id = 1;
             $user->name = 'Root';
             $user->email = 'root@notAGmail.com';
-            $user->password = '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi';
+            $user->password = Hash::make($defaultPassword);
             $user->is_admin = true;
+            $user->password_reset = true;
             $user->save();
         } else {
             // Create some teams...

--- a/resources/views/auth/change-password.blade.php
+++ b/resources/views/auth/change-password.blade.php
@@ -1,0 +1,44 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            Change Password
+        </h2>
+    </x-slot>
+    <div class="flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-gray-100">
+        <div class="w-full sm:max-w-md mt-6 px-6 py-4 bg-white shadow-md overflow-hidden sm:rounded-lg">
+
+            @if (isset($status) && $status)
+                <p>Password change successful!</p>
+                <x-timed-redirect time=5 route="dashboard" />
+            @else
+                <x-auth-validation-errors class="mb-4" :errors="$errors" />
+                <form method="POST" action="{{ route('password.change-store') }}">
+                    @csrf
+                    <div class="mt-4">
+                        <p class="p-2">{{isset($message) ? $message : "Create a new password."}}</p>
+                    </div>
+                    <!-- New Password -->
+                    <div class="mt-4">
+                        <x-label for="password" :value="__('New Password')" />
+
+                        <x-input id="password" class="block mt-1 w-full" type="password" name="password" required />
+                    </div>
+
+                    <!-- Confirm Password -->
+                    <div class="mt-4">
+                        <x-label for="password_confirmation" :value="__('Confirm Password')" />
+
+                        <x-input id="password_confirmation" class="block mt-1 w-full" type="password"
+                            name="password_confirmation" required />
+                    </div>
+
+                    <div class="flex items-center justify-end mt-4">
+                        <x-button>
+                            {{ __('Change Password') }}
+                        </x-button>
+                    </div>
+                </form>
+            @endif
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/components/timed-redirect.blade.php
+++ b/resources/views/components/timed-redirect.blade.php
@@ -1,0 +1,26 @@
+@props(['time', 'route'])
+
+
+<script>
+    var time = {{ $time }};
+    var route = "{{ route($route) }}";
+    setInterval(function() {
+        var seconds = time % 60;
+        var minutes = (time - seconds) / 60;
+        if (seconds.toString().length == 1) {
+            seconds = "0" + seconds;
+        }
+        if (minutes.toString().length == 1) {
+            minutes = "0" + minutes;
+        }
+        document.getElementById("time").innerHTML = minutes + ":" + seconds;
+        if (time == 0) {
+            window.location.href = route;
+        }
+        time--;
+    }, 1000);
+</script>
+
+<div class="p-2">
+    <strong>Redirect in: <span id="time"></span></strong>
+</div>

--- a/resources/views/users/approve-reset.blade.php
+++ b/resources/views/users/approve-reset.blade.php
@@ -1,0 +1,25 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            Approve Reset Password (Admin)
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200 p-6">
+                    <p class="text-red-500 pr-4">WARNING</p>
+                    Do you want to reset this user's password?
+                </div>
+                <div class="p-6 bg-white border-b border-gray-200">
+                    <ul>
+                        <li>{{$user->name}} (Email: {{$user->email}}) <a href="{{route('users')}}" class="text-blue-700 pl-6 
+                           pr-4">Cancel</a><a href="{{route('password.admin.apply-reset',[$user->id])}}" class="text-red-500 pr-4">Reset</a> 
+                       </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -37,13 +37,14 @@
                                 </tr>
                             </thead>
                             <tbody class="divide-y divide-gray-200 bg-white">
-                                @foreach($user as $user)
+                                @foreach($users as $user)
                                 <tr>
                                 <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">{{$user->name}} {{$user->deleted_at}}</td>
                                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{$user->email}}</td>
                                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{$user->team ? $user->team->name : "None"}}</td>
                                 <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
                                     <a href="{{route('users.editUser',[$user->id])}}" class="text-blue-600 hover:text-blue-900 px-4">Edit</a>
+                                    <a href="{{route('password.admin.approve-reset',[$user->id])}}" class="text-red-600 hover:text-red-900 px-4">Reset</a>
                                     <a href="{{route('users.confirm',[$user->id])}}" class="text-red-600 hover:text-red-900 px-4">Delete</a>
                                 </td>
                                 </tr>

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Auth\AuthenticatedSessionController;
+use App\Http\Controllers\Auth\ChangePasswordController;
 use App\Http\Controllers\Auth\ConfirmablePasswordController;
 use App\Http\Controllers\Auth\EmailVerificationNotificationController;
 use App\Http\Controllers\Auth\EmailVerificationPromptController;
@@ -12,45 +13,66 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('guest')->group(function () {
     Route::get('register', [RegisteredUserController::class, 'create'])
-                ->name('register');
+        ->name('register');
 
     Route::post('register', [RegisteredUserController::class, 'store']);
 
     Route::get('login', [AuthenticatedSessionController::class, 'create'])
-                ->name('login');
+        ->name('login');
 
     Route::post('login', [AuthenticatedSessionController::class, 'store']);
 
-    Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
-                ->name('password.request');
+    // Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
+    //     ->name('password.request');
 
-    Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
-                ->name('password.email');
+    // Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
+    //     ->name('password.email');
 
-    Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])
-                ->name('password.reset');
+    // Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])
+    //     ->name('password.reset');
 
-    Route::post('reset-password', [NewPasswordController::class, 'store'])
-                ->name('password.update');
+    // Route::post('reset-password', [NewPasswordController::class, 'store'])
+    //     ->name('password.update');
 });
 
 Route::middleware('auth')->group(function () {
-    Route::get('verify-email', [EmailVerificationPromptController::class, '__invoke'])
-                ->name('verification.notice');
+    // Route::get('verify-email', [EmailVerificationPromptController::class, '__invoke'])
+    //     ->name('verification.notice');
 
-    Route::get('verify-email/{id}/{hash}', [VerifyEmailController::class, '__invoke'])
-                ->middleware(['signed', 'throttle:6,1'])
-                ->name('verification.verify');
+    // Route::get('verify-email/{id}/{hash}', [VerifyEmailController::class, '__invoke'])
+    //     ->middleware(['signed', 'throttle:6,1'])
+    //     ->name('verification.verify');
 
-    Route::post('email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
-                ->middleware('throttle:6,1')
-                ->name('verification.send');
+    // Route::post('email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
+    //     ->middleware('throttle:6,1')
+    //     ->name('verification.send');
 
-    Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
-                ->name('password.confirm');
+    // Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
+    //     ->name('password.confirm');
 
-    Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
+    // Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
+
+
+    Route::controller(ChangePasswordController::class)
+        ->name('password')
+        ->group(function () {
+            Route::get('change-password', 'show')
+                ->name('.change-show');
+
+            Route::post('change-password', 'store')
+                ->name('.change-store');
+
+            Route::middleware(['admin'])
+                ->name('.admin')
+                ->group(function () {
+                    Route::get('users/{user}/approve-reset', 'approveReset')
+                        ->name('.approve-reset');
+
+                    Route::get('users/{user}/apply-reset', 'adminReset')
+                        ->name('.apply-reset');
+                });
+        });
 
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
-                ->name('logout');
+        ->name('logout');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,79 +24,80 @@ use App\Http\Controllers\UsersController;
 |--------------------------------------------------------------------------
 |*/
 
-
-Route::middleware(['auth'])->group(function () {
-    Route::get('/', function () {
-        return redirect('/dashboard');
-    });
-
-    Route::get('/dashboard', function () {
-        return view('dashboard');
-    })->name('dashboard');
-
-    Route::get('/activities', [ActivitiesController::class, 'index'])
-        ->name('activities');
-
-    Route::controller(ActivityLogController::class)
-        ->name('log')
-        ->group(function () {
-            Route::get('/log', 'viewLog');
-            Route::get('/log/{activity}', 'logActivity')
-                ->name('.activity');
+Route::middleware(['forceChangePassword'])->group(function () {
+    Route::middleware(['auth'])->group(function () {
+        Route::get('/', function () {
+            return redirect('/dashboard');
         });
 
-    Route::get('/profile', [UsersController::class, 'edit'])
-        ->name('users.edit');
+        Route::get('/dashboard', function () {
+            return view('dashboard');
+        })->name('dashboard');
 
-    Route::get('/teams', [TeamsController::class, 'index'])
-        ->name('teams');
-});
+        Route::get('/activities', [ActivitiesController::class, 'index'])
+            ->name('activities');
+
+        Route::controller(ActivityLogController::class)
+            ->name('log')
+            ->group(function () {
+                Route::get('/log', 'viewLog');
+                Route::get('/log/{activity}', 'logActivity')
+                    ->name('.activity');
+            });
+
+        Route::get('/profile', [UsersController::class, 'edit'])
+            ->name('users.edit');
+
+        Route::get('/teams', [TeamsController::class, 'index'])
+            ->name('teams');
+    });
 
 
-/*
+    /*
 |--------------------------------------------------------------------------
 | Admin Routes
 |--------------------------------------------------------------------------
 |*/
-Route::middleware(['auth', 'admin'])->group(function () {
+    Route::middleware(['auth', 'admin'])->group(function () {
 
-    Route::controller(ActivitiesController::class)
-        ->name('activities')
-        ->group(function () {
-            Route::get('/activities/create', 'create')
-                ->name('.create');
-            Route::post('/activities/create', 'store')
-                ->name('.store');
-        });
+        Route::controller(ActivitiesController::class)
+            ->name('activities')
+            ->group(function () {
+                Route::get('/activities/create', 'create')
+                    ->name('.create');
+                Route::post('/activities/create', 'store')
+                    ->name('.store');
+            });
 
-    Route::get('/users/{user}/log', [ActivityLogController::class, 'viewUserLog'])
-        ->name('users.log');
+        Route::get('/users/{user}/log', [ActivityLogController::class, 'viewUserLog'])
+            ->name('users.log');
 
-    Route::controller(UsersController::class)
-        ->name('users')
-        ->group(function () {
-            Route::get('/users', 'index');
-            Route::get('/users/{user}/edit', 'editUser')
-                ->name('.editUser');
-            Route::get('/users/{user}/confirm', 'confirm')
-                ->name('.confirm')
-                ->withTrashed();
-            Route::get('/users/{user}/delete', 'delete')
-                ->name('.delete');
-        });
+        Route::controller(UsersController::class)
+            ->name('users')
+            ->group(function () {
+                Route::get('/users', 'index');
+                Route::get('/users/{user}/edit', 'editUser')
+                    ->name('.editUser');
+                Route::get('/users/{user}/confirm', 'confirm')
+                    ->name('.confirm')
+                    ->withTrashed();
+                Route::get('/users/{user}/delete', 'delete')
+                    ->name('.delete');
+            });
 
-    Route::controller(TeamsController::class)
-        ->name('teams')
-        ->group(function () {
-            Route::get('/teams/create', 'create')
-                ->name('.create');
-            Route::post('/teams/create', 'store')
-                ->name('.store');
-            Route::get('/teams/{team}/edit', 'edit')
-                ->name('.edit');
-            Route::put('/teams/{team}/update', 'update')
-                ->name('.update');
-        });
+        Route::controller(TeamsController::class)
+            ->name('teams')
+            ->group(function () {
+                Route::get('/teams/create', 'create')
+                    ->name('.create');
+                Route::post('/teams/create', 'store')
+                    ->name('.store');
+                Route::get('/teams/{team}/edit', 'edit')
+                    ->name('.edit');
+                Route::put('/teams/{team}/update', 'update')
+                    ->name('.update');
+            });
+    });
 });
 
 // Route::get('/activities', function () {


### PR DESCRIPTION
This feature includes the following changes
* `Reset` option on /users page for admins to trigger a password reset w/ approval page before reset
* `password_reset` column in Users table and `ForceChangePassword` middleware used to redirect users upon password reset
* Commented out routes which will not be usable such as:
  * `/reset-password` which requires an email service
  * `/forgot-password`
  * `/verify-email`
  * `/confirm-password`